### PR TITLE
Add feature to open pasted url automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ By default, `pastery.vim` binds a hotkey to paste the currently selected section
 to F2. Just select a few lines, press that and you'll get a paste URL back very
 soon.
 
+## Extended Usage
+
+Pastery can automatically open the just-created URL for you if you want:
+
+```vim
+let g:pastery_open_in_browser = 1
+```
+
+`g:pastery_open_in_browser` defaults to 0 (false).
+
+The latest URL is stored in a Vim variable `pastery_result_url`.
 
 ## License
 


### PR DESCRIPTION
I'd like to see what was just pasted automatically to be opened in my web browser. This pull request adds a Vim setting to do that:

``` vim
let g:pastery_open_in_browser = 0|1
```

It's off (0) by default.

It also creates a vim variable, `pastery_result_url`, that contains the URL of the last pasted snippet (or the empty string). It does this regardless of the value of `g:pastery_open_in_browser`.
