### PR TITLE
Use autoloading for Python code.

### DIFF
--- a/autoload/pastery.vim
+++ b/autoload/pastery.vim
@@ -1,0 +1,58 @@
+let s:pyver = has("python3") ? "python3" : "python"
+
+function pastery#PasteCode(start, end)
+    exec s:pyver "PasteryPaste(" a:start "," a:end ")"
+endfunction
+
+function pastery#PasteFile()
+    exec s:pyver "PasteryPaste(title='" expand('%:t') "')"
+endfunction
+
+exec s:pyver . "<< EOF"
+import vim
+import json
+import webbrowser
+
+try:
+    from urllib.request import urlopen, Request, build_opener
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib2 import urlopen, Request, build_opener
+    from urllib import quote_plus
+
+def to_bool(s):
+  try:
+    return bool(int(s))
+  except ValueError:
+    return bool(x.strip())
+
+def PasteryPaste(start=None, end=None, title=""):
+    if start is None:
+        start = 1
+    if end is None:
+        end = len(vim.current.buffer)
+
+    api_key = vim.eval("g:pastery_apikey")
+    open_in_browser = to_bool(vim.eval("g:pastery_open_in_browser"))
+    copy_to_clipboard = to_bool(vim.eval("g:pastery_copy_to_clipboard"))
+
+    data = "\n".join(vim.current.buffer.range(start, end))
+
+    url = "https://www.pastery.net/api/paste/?language=%s&title=%s" % (vim.eval('&ft'), quote_plus(title))
+
+    if api_key:
+        url = url + "&api_key=" + api_key
+
+    req = Request(url, data=data.encode("utf8"), headers={'User-Agent': 'Mozilla/5.0 (Vim) Pastery plugin'})
+    response = urlopen(req)
+    if response.code != 200:
+        vim.command(':redraw | echo "Error while pasting."')
+    else:
+        pastery_result_url = json.loads(response.read().decode("utf8"))["url"]
+        vim.command(':let pastery_result_url = "{}"'.format(pastery_result_url))
+        if copy_to_clipboard:
+            vim.command(':let @+ = pastery_result_url')
+        vim.command(':redraw | echo "Paste URL: {}"'.format(pastery_result_url))
+        if open_in_browser:
+            webbrowser.open(pastery_result_url)
+EOF

--- a/plugin/pastery.vim
+++ b/plugin/pastery.vim
@@ -23,65 +23,10 @@ elseif !exists("g:pastery_copy_to_clipboard")
   let g:pastery_copy_to_clipboard = 1
 endif
 
-if has("python3")
-    " Paste a range.
-    :command! -range             PasteCode :py3 PasteryPaste(<line1>,<line2>)
-    " Paste a whole file.
-    :command!                    PasteFile :py3 PasteryPaste(title=vim.eval("expand('%:t')"))
-    let pyver = "python3"
-else
-    :command! -range             PasteCode :py PasteryPaste(<line1>,<line2>)
-    :command!                    PasteFile :py PasteryPaste(title=vim.eval("expand('%:t')"))
-    let pyver = "python"
-endif
+" Paste a range.
+command! -range PasteCode call pastery#PasteCode(<line1>,<line2>)
+
+" Paste a whole file.
+command! PasteFile call pastery#PasteFile()
 
 :vnoremap <f2> :PasteCode<cr>
-
-exec pyver . "<< EOF"
-def to_bool(s):
-  try:
-    return bool(int(s))
-  except ValueError:
-    return bool(x.strip())
-
-def PasteryPaste(start=None, end=None, title=""):
-    import vim
-    import json
-    import webbrowser
-
-    try:
-        from urllib.request import urlopen, Request, build_opener
-        from urllib.parse import quote_plus
-    except ImportError:
-        from urllib2 import urlopen, Request, build_opener
-        from urllib import quote_plus
-
-    if start is None:
-        start = 1
-    if end is None:
-        end = len(vim.current.buffer)
-
-    api_key = vim.eval("g:pastery_apikey")
-    open_in_browser = to_bool(vim.eval("g:pastery_open_in_browser"))
-    copy_to_clipboard = to_bool(vim.eval("g:pastery_copy_to_clipboard"))
-
-    data = "\n".join(vim.current.buffer.range(start, end))
-
-    url = "https://www.pastery.net/api/paste/?language=%s&title=%s" % (vim.eval('&ft'), quote_plus(title))
-
-    if api_key:
-        url = url + "&api_key=" + api_key
-
-    req = Request(url, data=data.encode("utf8"), headers={'User-Agent': 'Mozilla/5.0 (Vim) Pastery plugin'})
-    response = urlopen(req)
-    if response.code != 200:
-        vim.command(':redraw | echo "Error while pasting."')
-    else:
-        pastery_result_url = json.loads(response.read().decode("utf8"))["url"]
-        vim.command(':let pastery_result_url = "{}"'.format(pastery_result_url))
-        if copy_to_clipboard:
-            vim.command(':let @+ = pastery_result_url')
-        vim.command(':redraw | echo "Paste URL: {}"'.format(pastery_result_url))
-        if open_in_browser:
-            webbrowser.open(pastery_result_url)
-EOF


### PR DESCRIPTION
This considerably cuts down load time.  These are the values I previously got on a ThinkPad X220 running Arch Linux with Vim and Neovim, respectively:

    102.437  044.233  044.233: sourcing /home/meribold/.vim/pack/meribold/opt/pastery.vim/plugin/pastery.vim
    244.743  084.827  084.459: sourcing /home/meribold/.config/nvim/pack/meribold/opt/pastery.vim/plugin/pastery.vim

Now I get these values:

    058.102  000.068  000.068: sourcing /home/meribold/.vim/pack/meribold/opt/pastery.vim/plugin/pastery.vim
    156.885  001.137  000.816: sourcing /home/meribold/.config/nvim/pack/meribold/opt/pastery.vim/plugin/pastery.vim

Instead of about 40 or 80 milliseconds (depending on whether Vim or Neovim is used), pastery.vim now loads in a millisecond or less.

Note: Vim seems to use Python 2 and Neovim Python 3 on my system.

See <https://learnvimscriptthehardway.stevelosh.com/chapters/53.html> and `:h autoload`.
